### PR TITLE
Arredondando o valor da conversão

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,9 +10,11 @@ function converter() {
 
   if (tipo === "kgToLb") {
     resultado = valor * 2.20462;
+    resultado = Math.round(resultado * 100) / 100; // Arredondar para duas casas decimais
     document.getElementById('resultado').innerText = `${valor} kg = ${resultado.toFixed(2)} lb`;
   } else {
     resultado = valor * 0.453592;
+     resultado = Math.round(resultado * 100) / 100;
     document.getElementById('resultado').innerText = `${valor} lb = ${resultado.toFixed(2)} kg`;
   }
 }


### PR DESCRIPTION
Os valores de conversão estavam com uma quantidade desnecessária de casas decimais, então foi arredondado para um resultado com 2 casas decimais.